### PR TITLE
Streamline JAGS model and include new plots

### DIFF
--- a/neon_dynamic_disagg_multisp_JAGS.txt
+++ b/neon_dynamic_disagg_multisp_JAGS.txt
@@ -1,19 +1,19 @@
 model {
 
   # Priors
-  for (i in 1:5) {
+  for (i in 1:4) {
     mu_spec[i] ~ dnorm(0, 1)
     mu_site[i] = 0
   }
   
-  Tau_spec[1:5, 1:5] ~ dwish(R[1:5, 1:5], 10)
+  Tau_spec[1:4, 1:4] ~ dwish(R[1:4, 1:4], 10)
   for ( i in 1:K_exp) {
-    eps_spec[i, 1:5] ~ dmnorm(mu_spec, Tau_spec)
+    eps_spec[i, 1:4] ~ dmnorm(mu_spec, Tau_spec)
   }
   
-  Tau_site[1:5, 1:5] ~ dwish(R[1:5, 1:5], 10)
+  Tau_site[1:4, 1:4] ~ dwish(R[1:4, 1:4], 10)
   for (i in 1:nsite) {
-    eps_site[i, 1:5] ~ dmnorm(mu_site, Tau_site)
+    eps_site[i, 1:4] ~ dmnorm(mu_site, Tau_site)
   }
   
   for (i in 1:nsite){
@@ -25,16 +25,11 @@ model {
       logit_phi[i, k]   = eps_site[i, 2] + eps_spec[k, 2]
       phi[i, k]  = ilogit(logit_phi[i, k])
       
-      logit_p[i, k]     = eps_site[i, 3] + eps_spec[k, 3]
-      p[i, k]  = ilogit(logit_p[i, k])
-      
-      logit_gamma[i, k] = eps_site[i, 4] + eps_spec[k, 4]
+      logit_gamma[i, k] = eps_site[i, 3] + eps_spec[k, 3]
       gamma[i, k]  = ilogit(logit_gamma[i, k])
       
-      for (t in 1:nyear) {
-        log_lambda[i, k, t] = eps_site[i, 5] + eps_spec[k, 5]
-        lambda[i, k, t] = exp(log_lambda[i, k, t])
-      }
+      log_lambda[i, k] = eps_site[i, 4] + eps_spec[k, 4]
+      lambda[i, k] = exp(log_lambda[i, k])
     }
   }
   
@@ -50,7 +45,7 @@ model {
                         (1 - z[i,k,t-1])*gamma[i, k]) 
       }
       for (t in 1:nyear) {
-        zlam[i, k, t] = z[i, k, t] * lambda[i, k, t]
+        zlam[i, k, t] = z[i, k, t] * lambda[i, k]
       }
     }
   }
@@ -76,7 +71,7 @@ model {
       for (t in 2:nyear) {
         psi[i, k,t]        = psi[i, k, t-1]*phi[i, k] + 
                           (1 - psi[i, k, t-1])*gamma[i, k] 
-        growth[i, k, t]     = psi[i, k, t]/psi[i, k, t-1] 
+        log_growth[i, k, t]     = log(psi[i, k, t]) - log(psi[i, k, t-1]) 
         turnover[i, k, t-1] = (1 - psi[i, k, t-1])*gamma[i, k]/psi[i, k, t] 
       }
     }


### PR DESCRIPTION
Hey @annaspiers sorry for the big PR but this includes the following:

1) removes the unnecessary detection probability from the model
2) avoids redundant time index in lambda
3) fixes some stale paths from the original project's directory structure
4) computes log growth rate in JAGS
5) adds plots for site and species random effects


At the site level this is: 

![image](https://user-images.githubusercontent.com/2664564/90823635-710f9b80-e2f3-11ea-8dd3-b0ff7b5d9d17.png)

The rows in this plot correspond to the rows in the random effect covariance matrix, with elements corresponding to initial occupancy (row/col 1), persistence (row/col 2), colonization (row/col 3), and encounter rate (row/col 4). Marginal histograms of posterior medians are shown along the diagonal. Pairwise scatterplots are shown below the diagonal (each point is a site). The posterior density of the pairwise correlation is shown above the diagonal. Interpretation-wise, this plot shows that sites with high encounter rates tend to have lower colonization rates. And, sites with high encounter rates tend to have higher persistence rates. And, sites with higher colonization rates tend to have lower persistence rates. 

At the species level this is: 

![image](https://user-images.githubusercontent.com/2664564/90824091-19256480-e2f4-11ea-854b-c8cf354263dc.png)

This shows that species with high encounter rates tend to have high colonization rates. And, to a lesser extent, species with high initial occupancy tend to have higher persistence, colonization, and encounter rates. 
